### PR TITLE
perf: prellocate for camel transform

### DIFF
--- a/lib.rs
+++ b/lib.rs
@@ -17,7 +17,7 @@ impl<'a> StringCasesExt for &'a str {
 
     fn to_pascal_case(&self) -> String {
         let mut last_was_underscore_or_start = true;
-        let mut string = String::new();
+        let mut string = String::with_capacity(self.len());
         for chr in self.chars() {
             if chr == '_' {
                 last_was_underscore_or_start = true;
@@ -28,6 +28,7 @@ impl<'a> StringCasesExt for &'a str {
                 string.push(chr);
             }
         }
+        string.shrink_to_fit();
         string
     }
 }

--- a/lib.rs
+++ b/lib.rs
@@ -28,7 +28,6 @@ impl<'a> StringCasesExt for &'a str {
                 string.push(chr);
             }
         }
-        string.shrink_to_fit();
         string
     }
 }

--- a/lib.rs
+++ b/lib.rs
@@ -34,7 +34,7 @@ impl<'a> StringCasesExt for &'a str {
 
 pub(crate) fn apply_camel_transform(s: &str, divider: char) -> String {
     let mut peekable = s.chars().peekable();
-    let mut string = String::new();
+    let mut string = String::with_capacity(s.len());
     while let Some(character) = peekable.next() {
         if let '_' | '-' = character {
             string.push(divider);


### PR DESCRIPTION
Hello, just glanced at the code and saw this little optimization. It might still require allocating in the loop due to the underscore characters, but this would still be faster as we could use extra bytes in the capacity for the underscores.

It might also be viable to apply a similar system to the snake case to pascal where you would eagerly pre-allocate with the input length and then call [`String::shrink_to_fit()`](https://doc.rust-lang.org/std/string/struct.String.html#method.shrink_to_fit). The pre-allocation would be greater or equal to the actual needed bytes, so it would most likely not even require reallocation in most cases because strings are allocated with blocks of bytes.